### PR TITLE
Corrected python function int() input ValueError

### DIFF
--- a/src/ntf/docker/docker_node.py
+++ b/src/ntf/docker/docker_node.py
@@ -142,7 +142,7 @@ class DockerNode(Node):
             close_fds=False)
         pidp.wait()
         ps_out = pidp.stdout.readlines()
-        self.pid = int(ps_out[0])
+        self.pid = int(ps_out[0].replace("'",""))
         self.cmd('export PS1=\"\\177\"; printf "\\177"')
         self.cmd('stty -echo; set +m')
 


### PR DESCRIPTION
Former code displayed an error:
```
sudo ntf --topology switch/tests/ntf-tests/topology/l2_topology.json --config switch/tests/ntf-tests/topology/config.json --test-dir switch/tests/ntf-tests/ --test L2
[[25001, 9091], [25002, 9092]]
Traceback (most recent call last):
  File "/usr/local/bin/ntf", line 4, in <module>
    __import__('pkg_resources').run_script('ntf==0.1', 'ntf')
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 739, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 1494, in run_script
    exec(code, namespace, namespace)
  File "/usr/local/lib/python2.7/dist-packages/ntf-0.1-py2.7.egg/EGG-INFO/scripts/ntf", line 164, in <module>
    deployobj.deploy_switches()
  File "/usr/local/lib/python2.7/dist-packages/ntf-0.1-py2.7.egg/ntf/parse.py", line 139, in deploy_switches
    switch_info=sinfo)
  File "/usr/lib/python2.7/dist-packages/mininet/net.py", line 240, in addSwitch
    sw = cls( name, **defaults )
  File "/usr/local/lib/python2.7/dist-packages/ntf-0.1-py2.7.egg/ntf/docker/p4model.py", line 31, in __init__
    DockerSwitch.__init__(self, name, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/ntf-0.1-py2.7.egg/ntf/docker/docker_node.py", line 46, in __init__
    Node.__init__(self, name, **kwargs)
  File "/usr/lib/python2.7/dist-packages/mininet/node.py", line 106, in __init__
    self.startShell()
  File "/usr/local/lib/python2.7/dist-packages/ntf-0.1-py2.7.egg/ntf/docker/docker_node.py", line 145, in startShell
    self.pid = int(ps_out[0])
ValueError: invalid literal for int() with base 10: "'4460'"
```

--> error is related to *ps_out[0]* value is *"'4460'"*

The change only format ps_out([0]) to the right value '4460' 
subtle change "'4460'" --> '4460' after ps_out[0].replace("'","")